### PR TITLE
Support impOS 42’s imp006 bluetooth integration

### DIFF
--- a/.impt.test
+++ b/.impt.test
@@ -1,0 +1,12 @@
+{
+  "deviceGroupId": "59e87b61-3f99-aa04-e07b-bddf92ea8300",
+  "timeout": 450,
+  "stopOnFail": false,
+  "allowDisconnect": false,
+  "builderCache": false,
+  "testFiles": [
+    "*.test.nut",
+    "tests/**/*.test.nut"
+  ],
+  "deviceFile": "btleblinkup.device.lib.nut",
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Electric Imp
+Copyright (c) 2021 Twilio
 
 SPDX-License-Identifier: MIT
 

--- a/README.md
+++ b/README.md
@@ -239,7 +239,7 @@ This method advertises the imp to other Bluetooth LE-enabled devices using the a
 
 #### Return Value ####
 
-Nothing.
+Boolean — `true` if adverting began successfully, otherwise `false`.
 
 #### Example ####
 
@@ -250,6 +250,26 @@ bt.setSecurity(1);
 bt.serve();
 bt.advertise(advert, 90, 110);
 server.log("Bluetooth running...");
+```
+
+### close() ###
+
+This method stops advertising, disables BLE and nulls an instance’s *ble* property. Call this method to stop using BLE for BlinkUp.
+
+**Note** *advertise()* is called implicitly by [*listenForBlinkUp()*](#listenforblinkupadvert-callback).
+
+#### Return Value ####
+
+Nothing.
+
+#### Example ####
+
+```squirrel
+// Stop listening for BlinkUp signals after 5 mins (300s)
+imp.wakeup(300, function() {
+    bt.close();
+    server.log("BlinkUp no longer available - restart the device to re-enable.");
+});
 ```
 
 ### onConnect(*[callback]*) ###
@@ -283,7 +303,9 @@ Nothing.
 - 2.1.0
     - Updated to support imp API changes for imp006 (see [**Dependencies**](#dependencies), above).
     - Added GATT event reporting to *listenForBlinkUp()*.
+    - Added *close()* function.
     - Removed various *server.log()* calls.
+    - Updated code to deal with test-revealed issues.
 - 2.0.0
     - Initial imp006 support.
 - 1.0.0

--- a/README.md
+++ b/README.md
@@ -32,20 +32,9 @@ If you are working with the imp004m, this library requires the separate library 
 local bt = BTLEBlinkUp(serviceUUIDs, BT_FIRMWARE.CYW_43438);
 ```
 
-If you are working with the imp006, firmware is only required required for impOS 41.27 or under:
+If you are working with the imp006, firmware is not required with impOS 42 or above:
 
 ```squirrel
-// For imp006 on impOS 41.11
-#require "bt_firmware.lib.nut:1.0.0"
-#require "btleblinkup.device.lib.nut:2.1.0"
-
-local bt = BTLEBlinkUp(serviceUUIDs, BT_FIRMWARE.CYW_43455);
-```
-
-If you are working with the imp006 and all subsequent versions of impOS, including the production-ready impOS 42, you do not need to load firmware:
-
-```squirrel
-// For imp006 on impOS 42
 #require "btleblinkup.device.lib.nut:2.1.0"
 
 local bt = BTLEBlinkUp(serviceUUIDs);

--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
-# BTLEBlinkUp 3.0.0 #
+# BTLEBlinkUp 2.1.0 #
 
 This library provides a foundation for activating end-user devices via Bluetooth LE on imp modules that support this wireless technology (currently imp004m and imp006 only) using BlinkUp™.
 
 The BTLEBlinkUp library is intended for Electric Imp customers **only**. It contains device-side Squirrel code which enables BlinkUp device activation using enrollment and WiFi credentials transmitted by a companion app running on a mobile device. The companion app must contain the [Electric Imp BlinkUp SDK](https://developer.electricimp.com/manufacturing/sdkdocs), use of which is authorized by API key. Only Electric Imp customers can be provided with a suitable BlinkUp API key. Code for the companion app is not part of this library, but iOS example code is [available separately](https://github.com/electricimp/BluetoothBlinkUp).
 
-> **Important** Version 3.0.0 of this library supports impOS™ 41.28 and upwards **only**. This is due to changes made to the imp API’s [**hardware.bluetooth**](https://developer.electricimp.com/api/hardware/bluetooth) object and the integration of imp006 Bluetooth modem firmware into impOS. BTLEBlinkUp 3.0.0 assumes that this modem firmware has already been loaded; previous versions of the library performed firmware loading manually. This is a *de facto* breaking change.
-
-> If you are not running impOS 41.28 or above, please use [BTLEBlinkUp 2.0.0](https://github.com/electricimp/BTLEBlinkUp/tree/v2.0.0).
-
-**To include this library in your project, add** `#require "btleblinkup.device.lib.nut:3.0.0"` **at the top of your device code**.
+**To include this library in your project, add** `#require "btleblinkup.device.lib.nut:2.1.0"` **at the top of your device code**.
 
 ## Example Code ##
 
@@ -31,16 +27,26 @@ If you are working with the imp004m, this library requires the separate library 
 ```squirrel
 // For imp004m
 #require "bt_firmware.lib.nut:1.0.0"
-#require "btleblinkup.device.lib.nut:3.0.0"
+#require "btleblinkup.device.lib.nut:2.1.0"
 
 local bt = BTLEBlinkUp(serviceUUIDs, BT_FIRMWARE.CYW_43438);
 ```
 
-If you are working with the imp006, no firmware is required:
+If you are working with the imp006, firmware is only required required for impOS 41.27 or under:
 
 ```squirrel
-// For imp006
-#require "btleblinkup.device.lib.nut:3.0.0"
+// For imp006 on impOS 41.11
+#require "bt_firmware.lib.nut:1.0.0"
+#require "btleblinkup.device.lib.nut:2.1.0"
+
+local bt = BTLEBlinkUp(serviceUUIDs, BT_FIRMWARE.CYW_43455);
+```
+
+If you are working with the imp006 and all subsequent versions of impOS, including the production-ready impOS 42, you do not need to load firmware:
+
+```squirrel
+// For imp006 on impOS 42
+#require "btleblinkup.device.lib.nut:2.1.0"
 
 local bt = BTLEBlinkUp(serviceUUIDs);
 ```
@@ -274,8 +280,8 @@ Nothing.
 
 ## Release Notes ##
 
-- 3.0.0
-    - Requires impOS 41.28 or above. Please use 2.0.0 with earlier versions of impOS.
+- 2.1.0
+    - Updated to support imp API changes for imp006 (see [**Dependencies**](#dependencies), above).
 - 2.0.0
     - Initial imp006 support.
 - 1.0.0

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# BTLEBlinkUp 2.0.0 #
+# BTLEBlinkUp 3.0.0 #
 
 This library provides a foundation for activating end-user devices via Bluetooth LE on imp modules that support this wireless technology (currently imp004m and imp006 only) using BlinkUp™.
 
 The BTLEBlinkUp library is intended for Electric Imp customers **only**. It contains device-side Squirrel code which enables BlinkUp device activation using enrollment and WiFi credentials transmitted by a companion app running on a mobile device. The companion app must contain the [Electric Imp BlinkUp SDK](https://developer.electricimp.com/manufacturing/sdkdocs), use of which is authorized by API key. Only Electric Imp customers can be provided with a suitable BlinkUp API key. Code for the companion app is not part of this library, but iOS example code is [available separately](https://github.com/electricimp/BluetoothBlinkUp).
 
-**To include this library in your project, add** `#require "bt_firmware.lib.nut:1.0.0"` **and** `#require "btleblinkup.device.lib.nut:2.0.0"` **at the top of your device code**.
+> **Important** Version 3.0.0 of this library supports impOS™ 41.24 and upwards **only**. This is due to changes made to the imp API’s [**hardware.bluetooth**](https://developer.electricimp.com/api/hardware/bluetooth) object and the integration of imp006 Bluetooth modem firmware into impOS. BTLEBlinkUp 3.0.0 assumes that this modem firmware has already been loaded; previous versions of the library performed firmware loading manually. This is a *de facto* breaking change.
+
+> If you are not running impOS 41.24 or above, please use [BTLEBlinkUp 2.0.0](https://github.com/electricimp/BTLEBlinkUp/tree/v2.0.0).
+
+**To include this library in your project, add** `#require "btleblinkup.device.lib.nut:3.0.0"` **at the top of your device code**.
 
 ## Example Code ##
 
@@ -22,23 +26,22 @@ Please see [**How To Implement The Connected Factory Process**](https://develope
 
 ### Dependencies ###
 
-This library requires the separate library [Bluetooth Firmware](https://github.com/electricimp/BluetoothFirmware):
-
-```squirrel
-#require "bt_firmware.lib.nut:1.0.0"
-#require "btleblinkup.device.lib.nut:2.0.0"
-```
-
-One of the firmware versions included in [Bluetooth Firmware](https://github.com/electricimp/BluetoothFirmware) should then be included in your BTLEBlinkUp instantiation call:
+If you are working with the imp004m, this library requires the separate library [Bluetooth Firmware](https://github.com/electricimp/BluetoothFirmware) and the inclusion of a firmware version in your BTLEBlinkUp instantiation call:
 
 ```squirrel
 // For imp004m
+#require "bt_firmware.lib.nut:1.0.0"
+#require "btleblinkup.device.lib.nut:3.0.0"
+
 local bt = BTLEBlinkUp(serviceUUIDs, BT_FIRMWARE.CYW_43438);
 ```
 
+If you are working with the imp006, no firmware is required:
 ```squirrel
 // For imp006
-local bt = BTLEBlinkUp(serviceUUIDs, BT_FIRMWARE.CYW_43455);
+#require "btleblinkup.device.lib.nut:3.0.0"
+
+local bt = BTLEBlinkUp(serviceUUIDs);
 ```
 
 ### Constructor: BTLEBlinkUp(*uuids, firmware[, lpoPin][, regonPin][, uart]*) ###
@@ -53,7 +56,7 @@ local bt = BTLEBlinkUp(serviceUUIDs, BT_FIRMWARE.CYW_43455);
 | *regonPin* | imp **pin** object | No | The imp GPIO pin connected to the Bluetooth LE radio’s BT_REG_ON pin. Default: **hardware.pinJ** |
 | *uart* | imp **uart** object | No | The imp UART on which the imp’s Bluetooth radio is connected. Default: **hardware.uartFGJH** |
 
-**Note** The last three parameters are required only on the imp004m. imp006-based applications should not supply arguments to these parameters; indeed, they will be ignored if you do.
+**Note** The last four parameters are required **only on the imp004m**. imp006-based applications should not supply arguments to these parameters; indeed, they will be ignored if you do.
 
 #### BLE Service UUIDs ####
 
@@ -270,6 +273,8 @@ Nothing.
 
 ## Release Notes ##
 
+- 3.0.0
+    - Requires impOS 41.24 or above. Please use 2.0.0 with earlier versions of impOS.
 - 2.0.0
     - Support imp006.
 - 1.0.0

--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ Nothing.
 - 3.0.0
     - Requires impOS 41.28 or above. Please use 2.0.0 with earlier versions of impOS.
 - 2.0.0
-    - Support imp006.
+    - Initial imp006 support.
 - 1.0.0
     - Initial public release.
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ This library provides a foundation for activating end-user devices via Bluetooth
 
 The BTLEBlinkUp library is intended for Electric Imp customers **only**. It contains device-side Squirrel code which enables BlinkUp device activation using enrollment and WiFi credentials transmitted by a companion app running on a mobile device. The companion app must contain the [Electric Imp BlinkUp SDK](https://developer.electricimp.com/manufacturing/sdkdocs), use of which is authorized by API key. Only Electric Imp customers can be provided with a suitable BlinkUp API key. Code for the companion app is not part of this library, but iOS example code is [available separately](https://github.com/electricimp/BluetoothBlinkUp).
 
-> **Important** Version 3.0.0 of this library supports impOS™ 41.24 and upwards **only**. This is due to changes made to the imp API’s [**hardware.bluetooth**](https://developer.electricimp.com/api/hardware/bluetooth) object and the integration of imp006 Bluetooth modem firmware into impOS. BTLEBlinkUp 3.0.0 assumes that this modem firmware has already been loaded; previous versions of the library performed firmware loading manually. This is a *de facto* breaking change.
+> **Important** Version 3.0.0 of this library supports impOS™ 41.28 and upwards **only**. This is due to changes made to the imp API’s [**hardware.bluetooth**](https://developer.electricimp.com/api/hardware/bluetooth) object and the integration of imp006 Bluetooth modem firmware into impOS. BTLEBlinkUp 3.0.0 assumes that this modem firmware has already been loaded; previous versions of the library performed firmware loading manually. This is a *de facto* breaking change.
 
-> If you are not running impOS 41.24 or above, please use [BTLEBlinkUp 2.0.0](https://github.com/electricimp/BTLEBlinkUp/tree/v2.0.0).
+> If you are not running impOS 41.28 or above, please use [BTLEBlinkUp 2.0.0](https://github.com/electricimp/BTLEBlinkUp/tree/v2.0.0).
 
 **To include this library in your project, add** `#require "btleblinkup.device.lib.nut:3.0.0"` **at the top of your device code**.
 
@@ -37,6 +37,7 @@ local bt = BTLEBlinkUp(serviceUUIDs, BT_FIRMWARE.CYW_43438);
 ```
 
 If you are working with the imp006, no firmware is required:
+
 ```squirrel
 // For imp006
 #require "btleblinkup.device.lib.nut:3.0.0"
@@ -274,7 +275,7 @@ Nothing.
 ## Release Notes ##
 
 - 3.0.0
-    - Requires impOS 41.24 or above. Please use 2.0.0 with earlier versions of impOS.
+    - Requires impOS 41.28 or above. Please use 2.0.0 with earlier versions of impOS.
 - 2.0.0
     - Support imp006.
 - 1.0.0

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ This method provides the easiest way to provide BlinkUp via Bluetooth LE. It boo
 | *advert* | String or blob | No | The imp’s Bluetooth LE advertisement payload, up to 31 bytes in length. If you do not specify a payload, the library generates one for you using the BlinkUp service UUID (default or supplied) and the type of imp module as a device name string (eg. `imp004m`) |
 | *callback* | Function | No | A function which will be triggered when a remote device connects to the imp, or actively disconnects from it |
 
-The *callback* function has a single parameter of its own into which a table is passed containing any of the following keys:
+The *callback* function has a single parameter of its own into which a table is passed containing the following keys when connections are made or ended:
 
 | Key | Type | Notes |
 | --- | --- | --- |
@@ -96,6 +96,17 @@ The *callback* function has a single parameter of its own into which a table is 
 | *address* | String | The hexadecimal address of the connecting device |
 | *security* | Integer | The security mode of the connection (1, 3 or 4) |
 | *state* | String | The state of the remote device: `"connected"` or `"disconnected"` |
+
+If a GATT event is being reported, only these keys will be present:
+
+| Key | Type | Notes |
+| --- | --- | --- |
+| *gatt*  | Table | If the connection was caused by a GATT event, a table with the keys *service* and *characteristic* with UUIDs as values; otherwise `null` |
+
+If an error is being reported, only these keys will be present:
+
+| Key | Type | Notes |
+| --- | --- | --- |
 | *error* | String | In the event of an error, a description of the error; otherwise `null` |
 
 #### Return Value ####
@@ -271,6 +282,8 @@ Nothing.
 
 - 2.1.0
     - Updated to support imp API changes for imp006 (see [**Dependencies**](#dependencies), above).
+    - Added GATT event reporting to *listenForBlinkUp()*.
+    - Removed various *server.log()* calls.
 - 2.0.0
     - Initial imp006 support.
 - 1.0.0

--- a/btleblinkup.device.lib.nut
+++ b/btleblinkup.device.lib.nut
@@ -31,7 +31,7 @@ const BTLE_BLINKUP_WIFI_SCAN_INTERVAL = 120;
  * @constant {integer} BTLE_BLINKUP_MIN_IMPOS - The minimum version of impOS supported.
  *
 */
-const BTLE_BLINKUP_MIN_IMPOS = 41.24;
+const BTLE_BLINKUP_MIN_IMPOS = 41.28;
 
 /**
  * Squirrel class for providing BlinkUp services via Bluetooth LE on a compatible imp.

--- a/btleblinkup.device.lib.nut
+++ b/btleblinkup.device.lib.nut
@@ -118,7 +118,7 @@ class BTLEBlinkUp {
                 throw err;
             }
         } else {
-            throw format("BTLEBlinkUp() supports imp004m or imp006";
+            throw "BTLEBlinkUp() supports imp004m or imp006";
         }
 
         // Apply the BlinkUp service's UUIDs, or the defaults if none are provided

--- a/btleblinkup.device.lib.nut
+++ b/btleblinkup.device.lib.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright (c) 2019 Electric Imp, Inc.
+// Copyright (c) 2021 Twilio.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -113,7 +113,7 @@ class BTLEBlinkUp {
                 _version = version.slice(pos + 8, pos + 13).tofloat();
 
                 // No firmware? Thow on impOS less than min.
-                if (firmware == null && _version < BTLE_BLINKUP_MIN_IMPOS) throw format("BTLEBlinkUp() requires Bluetooth firmware supplied as a string or blob for imp006 on impOS undeer %.2f", BTLE_BLINKUP_MIN_IMPOS);
+                if (firmware == null && _version < BTLE_BLINKUP_MIN_IMPOS) throw format("BTLEBlinkUp() requires Bluetooth firmware supplied as a string or blob for imp006 on impOS under %.2f", BTLE_BLINKUP_MIN_IMPOS);
             } catch (err) {
                 throw err;
             }

--- a/tests/ble_setup.device.test.nut
+++ b/tests/ble_setup.device.test.nut
@@ -34,7 +34,7 @@ class BLESetupTestCase extends ImpTestCase {
 
         // Instantiate Bluetooth on a compatible device
         if (_isCompatible) {
-            _ble = BTLEBlinkUp(_initUUIDs(), (this._iType == "imp004m" ? BT_FIRMWARE.CYW_43438 : BT_FIRMWARE.CYW_43455));
+            _ble = this._iType == "imp004m" ? BTLEBlinkUp(_initUUIDs(), BT_FIRMWARE.CYW_43438) : BTLEBlinkUp(_initUUIDs());
 
             local result = (_ble != null);
             this.assertTrue(result, "BLEBlinkUp NOT running on " + this._iType);

--- a/tests/ble_setup.device.test.nut
+++ b/tests/ble_setup.device.test.nut
@@ -35,6 +35,84 @@ class BLESetupTestCase extends ImpTestCase {
         return "BLE BlinkUp running";
     }
 
+    function testSetSecurity() {
+
+        // CHECK FAILURE HANDLED CORRECTLY
+        this.info("Some calls will issue 'Device Runtime Error:' messages");
+        this.assert(_ble.setSecurity(2) == 1);
+        this.assert(_ble.setSecurity(5) == 1);
+        this.assert(_ble.setSecurity(4, null) == 1);
+        this.assert(_ble.setSecurity(4, "1234567") == 1);
+        this.assert(_ble.setSecurity(4, "ABCDEF") == 1);
+        this.assert(_ble.setSecurity(4, -1) == 1);
+        this.assert(_ble.setSecurity(4, 1000000) == 1);
+        this.assert(_ble.setSecurity(4, [123456]) == 1);
+        this.assert(_ble.setSecurity(4, {"pin": 123456}) == 1);
+        this.assert(_ble.setSecurity(4, 123456.01) == 1);
+
+        // CHECK SUCCESS HANDLED CORRECTLY
+        this.assert(_ble.setSecurity(4, 123456) == 4);
+        this.assert(_ble.setSecurity(1) == 1);
+        this.assert(_ble.setSecurity() == 1);
+    }
+
+    function testSetAgentURL() {
+
+        // CHECK FAILURE HANDLED CORRECTLY
+        this.assert(_ble.setAgentURL(42) == "");
+        this.assert(_ble.setAgentURL(true) == "");
+        this.assert(_ble.setAgentURL(42.42) == "");
+        this.assert(_ble.setAgentURL(["https://agent.electricimp.com/some_agent_id"]) == "");
+        this.assert(_ble.setAgentURL({"url": "https://agent.electricimp.com/some_agent_id"}) == "");
+
+        // CHECK SUCCESS HANDLED CORRECTLY
+        this.assert(_ble.setAgentURL("https://agent.electricimp.com/some_agent_id") == "https://agent.electricimp.com/some_agent_id");
+    }
+
+    function testAdvertise() {
+
+        // CHECK FAILURE HANDLED CORRECTLY
+        this.info("Some calls will issue 'Device Runtime Error:' messages");
+        local advert = "\x11\x07\x19\xD7\x68\xF3\x7C\xAF\xF2\xA5\xC9\x48\x55\xC4\xBE\x47\xDA\xFA\x08\x09\x69\x6D\x70\x30\x30\x34\x6D";
+        this.assert(_ble.advertise(["\x11\x07"]) == false);
+        this.assert(_ble.advertise({"ad":"\x11\x07"}) == false);
+        this.assert(_ble.advertise(42) == false);
+        this.assert(_ble.advertise(42.42) == false);
+        this.assert(_ble.advertise(true) == false);
+        this.assert(_ble.advertise(advert + "fsffdfssd") == false);
+
+        // CHECK SUCCESS HANDLED CORRECTLY
+        this.assert(_ble.advertise(advert) == true);
+        _ble.ble.stopadvertise();
+        this.assert(_ble.advertise() == true);
+    }
+
+    function testHexStringToInt() {
+
+        // CHECK OUTPUT CORRECT
+        this.assertTrue(_ble._hexStringToInt("FFFF") == 65535);
+        this.assertTrue(_ble._hexStringToInt("0A") == 10);
+    }
+
+    function testCheckUUIDs() {
+
+        // CHECK SUCCESS HANDLED CORRECTLY
+        local goodUUIDs = _initUUIDs();
+        this.assertTrue(_ble._checkUUIDs(goodUUIDs));
+
+        // CHECK FAILURE HANDLED CORRECTLY
+        local badUUIDs = {};
+        this.assert(_ble._checkUUIDs(badUUIDs) == false);
+    }
+
+    function tearDown() {
+
+        // Close BLE and confirm
+        _ble.close();
+        this.assert(_ble.ble == null);
+        return "BLE closed";
+    }
+
     // Auxilliary funtion to set the GATT service UUIDs we wil use
     // NOTE Take from the Bluetooth BlinkUp sample code
     function _initUUIDs() {

--- a/tests/ble_setup.device.test.nut
+++ b/tests/ble_setup.device.test.nut
@@ -2,9 +2,8 @@
  * BLEBlinkUp Library test cases
  *
  */
-
 @include "github:electricimp/BluetoothFirmware/bt_firmware.lib.nut"
-@include "github:electricimp/BTLEBlinkUp/btleblinkup.device.lib.nut@develop"
+
 
 class BLESetupTestCase extends ImpTestCase {
 
@@ -17,32 +16,23 @@ class BLESetupTestCase extends ImpTestCase {
      */
     function setUp() {
 
+        this.info("BTLEBlinkUp library version " + BTLEBlinkUp.VERSION);
+
         // Get the test imp’s type and report
         _iType = imp.info().type;
-        this.info("Test running on an " + _iType);
+        this.info("Tests running on an " + _iType);
 
         // Check that the imp is compatible
         _isCompatible = (_iType == "imp006" || _iType == "imp004m");
-        this.assertTrue(_isCompatible, "Test run on an incompatible imp");
-        return "Test running on a compatible imp";
-    }
+        this.assertTrue(_isCompatible, "Tests attempted on an incompatible imp");
+        this.info("Tests running on a compatible imp");
 
-    /**
-     * Test sensor readout in async mode
-     */
-    function testBLEInitReadout() {
+        // Instatiate the class
+        _ble = BTLEBlinkUp(_initUUIDs(), (this._iType == "imp004m" ? BT_FIRMWARE.CYW_43438 : BT_FIRMWARE.CYW_43455));
 
-        // Instantiate Bluetooth on a compatible device
-        if (_isCompatible) {
-            _ble = BTLEBlinkUp(_initUUIDs(), (this._iType == "imp004m" ? BT_FIRMWARE.CYW_43438 : BT_FIRMWARE.CYW_43455));
-
-            local result = (_ble != null);
-            this.assertTrue(result, "BLEBlinkUp NOT running on " + this._iType);
-            return "BLEBlinkUp running";
-        }
-
-        this.assertTrue(_isCompatible, "Test run on an incompatible imp");
-        return;
+        local result = (_ble != null);
+        this.assertTrue(result, "BLE BlinkUp NOT running on " + this._iType);
+        return "BLE BlinkUp running";
     }
 
     // Auxilliary funtion to set the GATT service UUIDs we wil use

--- a/tests/ble_setup.device.test.nut
+++ b/tests/ble_setup.device.test.nut
@@ -1,9 +1,7 @@
 /**
  * BLEBlinkUp Library test cases
- * Configuration with enable pin
+ *
  */
-
-const BTLE_BLINKUP_MIN_IMPOS = 41.28;
 
 @include "github:electricimp/BluetoothFirmware/bt_firmware.lib.nut"
 @include "github:electricimp/BTLEBlinkUp/btleblinkup.device.lib.nut@develop"
@@ -13,28 +11,15 @@ class BLESetupTestCase extends ImpTestCase {
     _ble = null;
     _iType = null;
     _isCompatible = false;
-    _impOSVersion = "41";
 
+    /**
+     * Get the imp Type (impp04m or imp006)
+     */
     function setUp() {
-
-        // Get the impOS version
-        local version = imp.getsoftwareversion();
-        local pos = version.find("release");
-        _impOSVersion = version.slice(pos + 8, pos + 13).tofloat();
 
         // Get the test imp’s type and report
         _iType = imp.info().type;
-        this.info("Test running on an " + _iType + " (impOS " + _impOSVersion + ")");
-
-        if (_iType == "imp006") {
-            if (_impOSVersion < BTLE_BLINKUP_MIN_IMPOS) {
-                // Need to be running BTLEBlinkUp 2.0.0
-                this.assertTrue(BTLEBlinkUp.VERSION == "2.0.0", "Test run on imp006 with impOS < 41.28 -- test with BTLEBlinkUp 2.0.0");
-            } else {
-                // Need to be running BTLEBlinkUp 3.0.0
-                this.assertTrue(BTLEBlinkUp.VERSION == "3.0.0", "Test run on imp006 with impOS >= 41.28 -- test with BTLEBlinkUp 3.0.0");
-            }
-        }
+        this.info("Test running on an " + _iType);
 
         // Check that the imp is compatible
         _isCompatible = (_iType == "imp006" || _iType == "imp004m");
@@ -42,11 +27,14 @@ class BLESetupTestCase extends ImpTestCase {
         return "Test running on a compatible imp";
     }
 
+    /**
+     * Test sensor readout in async mode
+     */
     function testBLEInitReadout() {
 
         // Instantiate Bluetooth on a compatible device
         if (_isCompatible) {
-            _ble = this._iType == "imp004m" ? BTLEBlinkUp(_initUUIDs(), BT_FIRMWARE.CYW_43438) : (_impOSVersion < BTLE_BLINKUP_MIN_IMPOS ? BTLEBlinkUp(_initUUIDs(), BT_FIRMWARE.CYW_43455) : BTLEBlinkUp(_initUUIDs()));
+            _ble = BTLEBlinkUp(_initUUIDs(), (this._iType == "imp004m" ? BT_FIRMWARE.CYW_43438 : BT_FIRMWARE.CYW_43455));
 
             local result = (_ble != null);
             this.assertTrue(result, "BLEBlinkUp NOT running on " + this._iType);


### PR DESCRIPTION
Release 41.28 incorporates BLE firmware for imp006; BTLEBlinkUp has been updated accordingly (to 3.0.0)